### PR TITLE
dump() failed removal of the trigger

### DIFF
--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTrigger.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTrigger.groovy
@@ -143,7 +143,7 @@ abstract class JiraTrigger<T> extends Trigger<Job> {
                 log.finest("Removed [${jiraTrigger.job.fullName}]:[${jiraTrigger.class.simpleName}] from triggers list")
             } else {
                 log.warning(
-                        "Bug! Failed to remove [${jiraTrigger.job.fullName}]:[${jiraTrigger.class.simpleName}] " +
+                        "Bug! Failed to remove [${jiraTrigger.dump()}]:[${jiraTrigger.class.simpleName}] " +
                                 'from triggers list. ' +
                                 'The job might accidentally be triggered by JIRA. Restart Jenkins to recover.')
             }


### PR DESCRIPTION
when a JiraTrigger is removed it is not guarantied the job property is populated at all.

We experienced a NPE because of this. When it run with this change, subsequent removal went just fine, so Jenkins had stored somewhere corrupted JiraTriggers or perhaps they were orphaned