### PR TITLE
upgrade jenkins core to 2.76.  Making EnvironmentContributingAction working under pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ tasks.withType(Test) {
 }
 
 jenkinsPlugin {
-    coreVersion = '2.164'
+    coreVersion = '2.76'
     shortName = 'jira-trigger'
     displayName = 'JIRA Trigger Plugin'
     url = 'http://wiki.jenkins-ci.org/display/JENKINS/JIRA+Trigger+Plugin'

--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ tasks.withType(Test) {
 }
 
 jenkinsPlugin {
-    coreVersion = '2.73'
+    coreVersion = '2.164'
     shortName = 'jira-trigger'
     displayName = 'JIRA Trigger Plugin'
     url = 'http://wiki.jenkins-ci.org/display/JENKINS/JIRA+Trigger+Plugin'

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
@@ -4,6 +4,9 @@ import com.atlassian.jira.rest.client.api.domain.Issue
 import hudson.EnvVars
 import hudson.model.AbstractBuild
 import hudson.model.EnvironmentContributingAction
+import hudson.model.Run
+
+import javax.annotation.Nonnull
 
 /**
  * @author ceilfors
@@ -17,7 +20,13 @@ class JiraIssueEnvironmentContributingAction implements EnvironmentContributingA
     }
 
     @Override
+    @Deprecated
     void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
+        env.put('JIRA_ISSUE_KEY', issueKey)
+    }
+
+    @Override
+    void buildEnvironment(@Nonnull Run<?, ?> run, @Nonnull EnvVars env) {
         env.put('JIRA_ISSUE_KEY', issueKey)
     }
 

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
@@ -22,7 +22,7 @@ class JiraIssueEnvironmentContributingAction implements EnvironmentContributingA
     @Override
     @Deprecated
     void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
-        buildEnvironment(build,env)
+        buildEnvironment(build, env)
     }
 
     @Override

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraIssueEnvironmentContributingAction.groovy
@@ -22,7 +22,7 @@ class JiraIssueEnvironmentContributingAction implements EnvironmentContributingA
     @Override
     @Deprecated
     void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
-        env.put('JIRA_ISSUE_KEY', issueKey)
+        buildEnvironment(build,env)
     }
 
     @Override


### PR DESCRIPTION
according to https://github.com/jenkinsci/jenkins/pull/2993.
`EnvironmentContributingAction`'s `buildEnvVars` was deprecated since `2.76`, the new added `buildEnvironment` is pipeline compatible.