### PR TITLE
JENKINS-58987 Update dependency to jira-rest-java-client-core:5.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ configurations {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.11'
-    compile('com.atlassian.jira:jira-rest-java-client-core:3.0.0') {
+    compile('com.atlassian.jira:jira-rest-java-client-core:5.2.1') {
         exclude group: 'org.slf4j'
     }
     compile 'com.google.inject.extensions:guice-multibindings:4.0'

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/jira/AsynchronousWebhookRestClient.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/jira/AsynchronousWebhookRestClient.groovy
@@ -3,7 +3,7 @@ package com.ceilfors.jenkins.plugins.jiratrigger.jira
 import com.atlassian.httpclient.api.HttpClient
 import com.atlassian.jira.rest.client.internal.async.AbstractAsynchronousRestClient
 import com.atlassian.jira.rest.client.internal.json.JsonParser
-import com.atlassian.util.concurrent.Promise
+import io.atlassian.util.concurrent.Promise
 
 import javax.ws.rs.core.UriBuilder
 

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/jira/WebhookRestClient.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/jira/WebhookRestClient.groovy
@@ -1,6 +1,6 @@
 package com.ceilfors.jenkins.plugins.jiratrigger.jira
 
-import com.atlassian.util.concurrent.Promise
+import io.atlassian.util.concurrent.Promise
 
 /**
  * @author ceilfors


### PR DESCRIPTION
Similar to the fix done here:
https://github.com/jenkinsci/jira-plugin/pull/213

for latest API changes done by Atlassian