### PR TITLE
JENKINS-66646 - Guard against exceptions when triggering

### DIFF
--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
@@ -13,6 +13,7 @@ import jenkins.model.Jenkins
 
 import javax.inject.Inject
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.logging.Level
 
 import static com.ceilfors.jenkins.plugins.jiratrigger.JiraTrigger.JiraTriggerDescriptor
 
@@ -76,9 +77,13 @@ class JiraTriggerExecutor implements JiraWebhookListener {
         List<AbstractProject> scheduledProjects = []
         List<? extends JiraTrigger> triggers = getTriggers(triggerClass)
         for (trigger in triggers) {
-            boolean scheduled = trigger.run(issue, jiraObject)
-            if (scheduled) {
-                scheduledProjects << trigger.job
+            try {
+                boolean scheduled = trigger.run(issue, jiraObject)
+                if (scheduled) {
+                    scheduledProjects << trigger.job
+                }
+            } catch (e) {
+                log.log(Level.WARNING, e, {"Error triggering \"${trigger.job?.fullName}\""})
             }
         }
         scheduledProjects

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
@@ -83,7 +83,9 @@ class JiraTriggerExecutor implements JiraWebhookListener {
                     scheduledProjects << trigger.job
                 }
             } catch (e) {
-                log.log(Level.WARNING, e, {"Error triggering \"${trigger.job?.fullName}\""})
+                log.log(Level.WARNING, e) {
+                    "Error triggering \"${trigger.job?.fullName}\""
+                }
             }
         }
         scheduledProjects


### PR DESCRIPTION
A trigger is calling a JiraClient API which can fail with an exception. The running of every trigger is wrapped in a try/catch to ensure exception only fails one trigger, not all the consecutive. The exception is logged at the warning level for troubleshooting purposes.

It should resolve https://issues.jenkins.io/browse/JENKINS-66646, but I do not have the environment and time to test it properly.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~Link to relevant pull requests, esp. upstream and downstream changes~
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
