### PR TITLE
JENKINS-66646 - Fix ClassCastException in logging because Groovy

### DIFF
--- a/src/integrationTest/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerIntegrationTest.groovy
+++ b/src/integrationTest/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerIntegrationTest.groovy
@@ -226,18 +226,16 @@ class JiraTriggerIntegrationTest extends Specification {
     @Issue('JENKINS-66646')
     def 'Should not let Jira client exception bubble up'() {
         given:
-        def testIssueKey = "JENKINS-66646"
-        def testFilter = 'foo = bar'
-        def project = jenkins.createJiraChangelogTriggeredProject(testIssueKey)
-        project.jiraTrigger.jqlFilter = testFilter
+        def project = jenkins.createJiraChangelogTriggeredProject('JENKINS-66646')
+        project.jiraTrigger.jqlFilter = 'foo = bar'
         // I tried to use `Stub` here but couldn't make it work for unclear reason.
         jenkins.jiraClient = new JiraClient() {
             @Override
-            void addComment(String issueKey, String comment) {}
+            void addComment(String issueKey, String comment) { /* unused */ }
 
             @Override
             boolean validateIssueKey(String issueKey, String jqlFilter) {
-                throw new RestClientException([new ErrorCollection("Bad JQL")], 400)
+                throw new RestClientException([new ErrorCollection('Bad JQL')], 400)
             }
         }
 

--- a/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
+++ b/src/main/groovy/com/ceilfors/jenkins/plugins/jiratrigger/JiraTriggerExecutor.groovy
@@ -84,7 +84,7 @@ class JiraTriggerExecutor implements JiraWebhookListener {
                 }
             } catch (e) {
                 log.log(Level.WARNING, e) {
-                    "Error triggering \"${trigger.job?.fullName}\""
+                    "Error triggering \"${trigger.job?.fullName}\"".toString()
                 }
             }
         }


### PR DESCRIPTION
[\[JENKINS-66646\] Issue with incorrect JQL processing - Jenkins Jira](https://issues.jenkins.io/browse/JENKINS-66646)
Follows up #15 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

An integration test is added that executes the `catch` with logging logic. It failed because `ClassCastException` bubled up. The exception is fixed by `.toString()` which turns Groovy string into plain java `String` which logger expects

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
